### PR TITLE
Simplify contributors page

### DIFF
--- a/about/contributors.md
+++ b/about/contributors.md
@@ -9,509 +9,60 @@ permalink: /contributors/
 <div class="contributors-page">
 
 <div class="contributors-header">
-<h1>🌟 Contributors</h1>
-<p class="subtitle">Thank you to all the amazing people who have contributed to the control-toolbox ecosystem!</p>
-<p class="last-update">Last updated: August 03, 2026 at 03:43 (France)</p>
+<h1>Contributors</h1>
+<p class="subtitle">Contributors to the control-toolbox ecosystem</p>
+<p class="last-update">Last updated: August 03, 2026 at 15:03 (France)</p>
 </div>
 
-<div class="summary-cards">
-<div class="summary-card card-repos">
-<div class="card-label">Repositories</div>
-<div class="card-value">25</div>
-</div>
-<div class="summary-card card-contributors">
-<div class="card-label">Contributors</div>
-<div class="card-value">32</div>
-</div>
-<div class="summary-card card-commits">
-<div class="card-label">Total Commits</div>
-<div class="card-value">10,399</div>
-</div>
-</div>
-
-<div class="info-box">
-<p><strong>Note:</strong> Contributions represent commits made to the repositories. Bots are excluded from the statistics. </p>
-</div>
+<dl class="summary">
+<div><dt>Repositories</dt>
+<dd>25</dd></div>
+<div><dt>Contributors</dt>
+<dd>32</dd></div>
+<div><dt>Total commits</dt>
+<dd>10,400</dd></div>
+</dl>
 
 <div class="contributors-section">
-<h2>👥 All Contributors</h2>
-<div class="contributors-inline">
-<span class="contributor-item"><a href="https://github.com/ocots" class="contributor-name">ocots</a> <span class="contributor-count">(7837)</span></span>, <span class="contributor-item"><a href="https://github.com/jbcaillau" class="contributor-name">jbcaillau</a> <span class="contributor-count">(1170)</span></span>, <span class="contributor-item"><a href="https://github.com/PierreMartinon" class="contributor-name">PierreMartinon</a> <span class="contributor-count">(509)</span></span>, <span class="contributor-item"><a href="https://github.com/0Yassine0" class="contributor-name">0Yassine0</a> <span class="contributor-count">(200)</span></span>, <span class="contributor-item"><a href="https://github.com/BaptisteCbl" class="contributor-name">BaptisteCbl</a> <span class="contributor-count">(151)</span></span>, <span class="contributor-item"><a href="https://github.com/j-l-s" class="contributor-name">j-l-s</a> <span class="contributor-count">(140)</span></span>, <span class="contributor-item"><a href="https://github.com/AnasXbouali" class="contributor-name">AnasXbouali</a> <span class="contributor-count">(71)</span></span>, <span class="contributor-item"><a href="https://github.com/gergaud" class="contributor-name">gergaud</a> <span class="contributor-count">(65)</span></span>, <span class="contributor-item"><a href="https://github.com/AmielMetier" class="contributor-name">AmielMetier</a> <span class="contributor-count">(65)</span></span>, <span class="contributor-item"><a href="https://github.com/agustinyabo" class="contributor-name">agustinyabo</a> <span class="contributor-count">(24)</span></span>, <span class="contributor-item"><a href="https://github.com/antoinepichon03" class="contributor-name">antoinepichon03</a> <span class="contributor-count">(23)</span></span>, <span class="contributor-item"><a href="https://github.com/HediChennoufi" class="contributor-name">HediChennoufi</a> <span class="contributor-count">(19)</span></span>, <span class="contributor-item"><a href="https://github.com/Yassin-Moukan" class="contributor-name">Yassin-Moukan</a> <span class="contributor-count">(18)</span></span>, <span class="contributor-item"><a href="https://github.com/baillietn" class="contributor-name">baillietn</a> <span class="contributor-count">(15)</span></span>, <span class="contributor-item"><a href="https://github.com/alegoupil" class="contributor-name">alegoupil</a> <span class="contributor-count">(11)</span></span>, <span class="contributor-item"><a href="https://github.com/remydutto" class="contributor-name">remydutto</a> <span class="contributor-count">(11)</span></span>, <span class="contributor-item"><a href="https://github.com/abavoil" class="contributor-name">abavoil</a> <span class="contributor-count">(10)</span></span>, <span class="contributor-item"><a href="https://github.com/amontoison" class="contributor-name">amontoison</a> <span class="contributor-count">(10)</span></span>, <span class="contributor-item"><a href="https://github.com/Ousmane-prog" class="contributor-name">Ousmane-prog</a> <span class="contributor-count">(10)</span></span>, <span class="contributor-item"><a href="https://github.com/YouriRenoud" class="contributor-name">YouriRenoud</a> <span class="contributor-count">(9)</span></span>, <span class="contributor-item"><a href="https://github.com/ade4569" class="contributor-name">ade4569</a> <span class="contributor-count">(6)</span></span>, <span class="contributor-item"><a href="https://github.com/srcansiz" class="contributor-name">srcansiz</a> <span class="contributor-count">(5)</span></span>, <span class="contributor-item"><a href="https://github.com/michel2323" class="contributor-name">michel2323</a> <span class="contributor-count">(4)</span></span>, <span class="contributor-item"><a href="https://github.com/tmigot" class="contributor-name">tmigot</a> <span class="contributor-count">(3)</span></span>, <span class="contributor-item"><a href="https://github.com/oameye" class="contributor-name">oameye</a> <span class="contributor-count">(3)</span></span>, <span class="contributor-item"><a href="https://github.com/gdalle" class="contributor-name">gdalle</a> <span class="contributor-count">(3)</span></span>, <span class="contributor-item"><a href="https://github.com/loxim3" class="contributor-name">loxim3</a> <span class="contributor-count">(2)</span></span>, <span class="contributor-item"><a href="https://github.com/mjacobse" class="contributor-name">mjacobse</a> <span class="contributor-count">(1)</span></span>, <span class="contributor-item"><a href="https://github.com/vmerc" class="contributor-name">vmerc</a> <span class="contributor-count">(1)</span></span>, <span class="contributor-item"><a href="https://github.com/Lupylune" class="contributor-name">Lupylune</a> <span class="contributor-count">(1)</span></span>, <span class="contributor-item"><a href="https://github.com/frapac" class="contributor-name">frapac</a> <span class="contributor-count">(1)</span></span>, <span class="contributor-item"><a href="https://github.com/BWembe" class="contributor-name">BWembe</a> <span class="contributor-count">(1)</span></span>
-</div>
-</div>
-
-<div class="contributors-section">
-<h2>🏆 Top 10 Contributors</h2>
-<ol class="top-contributors-list">
-<li><a href="https://github.com/ocots" class="contributor-name">ocots</a> — <span class="contributor-stats">7,837 contributions (75.4%)</span></li>
-<li><a href="https://github.com/jbcaillau" class="contributor-name">jbcaillau</a> — <span class="contributor-stats">1,170 contributions (11.3%)</span></li>
-<li><a href="https://github.com/PierreMartinon" class="contributor-name">PierreMartinon</a> — <span class="contributor-stats">509 contributions (4.9%)</span></li>
-<li><a href="https://github.com/0Yassine0" class="contributor-name">0Yassine0</a> — <span class="contributor-stats">200 contributions (1.9%)</span></li>
-<li><a href="https://github.com/BaptisteCbl" class="contributor-name">BaptisteCbl</a> — <span class="contributor-stats">151 contributions (1.5%)</span></li>
-<li><a href="https://github.com/j-l-s" class="contributor-name">j-l-s</a> — <span class="contributor-stats">140 contributions (1.3%)</span></li>
-<li><a href="https://github.com/AnasXbouali" class="contributor-name">AnasXbouali</a> — <span class="contributor-stats">71 contributions (0.7%)</span></li>
-<li><a href="https://github.com/gergaud" class="contributor-name">gergaud</a> — <span class="contributor-stats">65 contributions (0.6%)</span></li>
-<li><a href="https://github.com/AmielMetier" class="contributor-name">AmielMetier</a> — <span class="contributor-stats">65 contributions (0.6%)</span></li>
-<li><a href="https://github.com/agustinyabo" class="contributor-name">agustinyabo</a> — <span class="contributor-stats">24 contributions (0.2%)</span></li>
+<h2>Contributors</h2>
+<ol class="contributors-list">
+<li><a href="https://github.com/ocots">ocots</a></li>
+<li><a href="https://github.com/jbcaillau">jbcaillau</a></li>
+<li><a href="https://github.com/PierreMartinon">PierreMartinon</a></li>
+<li><a href="https://github.com/0Yassine0">0Yassine0</a></li>
+<li><a href="https://github.com/BaptisteCbl">BaptisteCbl</a></li>
+<li><a href="https://github.com/j-l-s">j-l-s</a></li>
+<li><a href="https://github.com/AnasXbouali">AnasXbouali</a></li>
+<li><a href="https://github.com/gergaud">gergaud</a></li>
+<li><a href="https://github.com/AmielMetier">AmielMetier</a></li>
+<li><a href="https://github.com/agustinyabo">agustinyabo</a></li>
+<li><a href="https://github.com/antoinepichon03">antoinepichon03</a></li>
+<li><a href="https://github.com/HediChennoufi">HediChennoufi</a></li>
+<li><a href="https://github.com/Yassin-Moukan">Yassin-Moukan</a></li>
+<li><a href="https://github.com/baillietn">baillietn</a></li>
+<li><a href="https://github.com/alegoupil">alegoupil</a></li>
+<li><a href="https://github.com/remydutto">remydutto</a></li>
+<li><a href="https://github.com/abavoil">abavoil</a></li>
+<li><a href="https://github.com/amontoison">amontoison</a></li>
+<li><a href="https://github.com/Ousmane-prog">Ousmane-prog</a></li>
+<li><a href="https://github.com/YouriRenoud">YouriRenoud</a></li>
+<li><a href="https://github.com/ade4569">ade4569</a></li>
+<li><a href="https://github.com/srcansiz">srcansiz</a></li>
+<li><a href="https://github.com/michel2323">michel2323</a></li>
+<li><a href="https://github.com/tmigot">tmigot</a></li>
+<li><a href="https://github.com/oameye">oameye</a></li>
+<li><a href="https://github.com/gdalle">gdalle</a></li>
+<li><a href="https://github.com/loxim3">loxim3</a></li>
+<li><a href="https://github.com/mjacobse">mjacobse</a></li>
+<li><a href="https://github.com/vmerc">vmerc</a></li>
+<li><a href="https://github.com/Lupylune">Lupylune</a></li>
+<li><a href="https://github.com/frapac">frapac</a></li>
+<li><a href="https://github.com/BWembe">BWembe</a></li>
 </ol>
 </div>
 
 <div class="contributors-section">
-<h2>📊 Detailed Ranking</h2>
-<table class="contributors-table">
-<thead>
-<tr>
-<th>Rank</th>
-<th>Contributor</th>
-<th>Contributions</th>
-<th>Percentage</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><span class="rank-badge top-1">1</span></td>
-<td><a href="https://github.com/ocots" class="contributor-link">ocots</a></td>
-<td>7,837</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 75.3630156745841%"></div>
-</div>
-<span class="percentage-text">75.4%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge top-2">2</span></td>
-<td><a href="https://github.com/jbcaillau" class="contributor-link">jbcaillau</a></td>
-<td>1,170</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 11.251081834791806%"></div>
-</div>
-<span class="percentage-text">11.3%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge top-3">3</span></td>
-<td><a href="https://github.com/PierreMartinon" class="contributor-link">PierreMartinon</a></td>
-<td>509</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 4.894701413597461%"></div>
-</div>
-<span class="percentage-text">4.9%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge top-10">4</span></td>
-<td><a href="https://github.com/0Yassine0" class="contributor-link">0Yassine0</a></td>
-<td>200</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 1.9232618521011637%"></div>
-</div>
-<span class="percentage-text">1.9%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge top-10">5</span></td>
-<td><a href="https://github.com/BaptisteCbl" class="contributor-link">BaptisteCbl</a></td>
-<td>151</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 1.4520626983363785%"></div>
-</div>
-<span class="percentage-text">1.5%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge top-10">6</span></td>
-<td><a href="https://github.com/j-l-s" class="contributor-link">j-l-s</a></td>
-<td>140</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 1.3462832964708145%"></div>
-</div>
-<span class="percentage-text">1.3%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge top-10">7</span></td>
-<td><a href="https://github.com/AnasXbouali" class="contributor-link">AnasXbouali</a></td>
-<td>71</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.6827579574959131%"></div>
-</div>
-<span class="percentage-text">0.7%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge top-10">8</span></td>
-<td><a href="https://github.com/gergaud" class="contributor-link">gergaud</a></td>
-<td>65</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.6250601019328781%"></div>
-</div>
-<span class="percentage-text">0.6%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge top-10">9</span></td>
-<td><a href="https://github.com/AmielMetier" class="contributor-link">AmielMetier</a></td>
-<td>65</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.6250601019328781%"></div>
-</div>
-<span class="percentage-text">0.6%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge top-10">10</span></td>
-<td><a href="https://github.com/agustinyabo" class="contributor-link">agustinyabo</a></td>
-<td>24</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.2307914222521396%"></div>
-</div>
-<span class="percentage-text">0.2%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge other">11</span></td>
-<td><a href="https://github.com/antoinepichon03" class="contributor-link">antoinepichon03</a></td>
-<td>23</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.2211751129916338%"></div>
-</div>
-<span class="percentage-text">0.2%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge other">12</span></td>
-<td><a href="https://github.com/HediChennoufi" class="contributor-link">HediChennoufi</a></td>
-<td>19</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.18270987594961055%"></div>
-</div>
-<span class="percentage-text">0.2%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge other">13</span></td>
-<td><a href="https://github.com/Yassin-Moukan" class="contributor-link">Yassin-Moukan</a></td>
-<td>18</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.17309356668910472%"></div>
-</div>
-<span class="percentage-text">0.2%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge other">14</span></td>
-<td><a href="https://github.com/baillietn" class="contributor-link">baillietn</a></td>
-<td>15</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.14424463890758726%"></div>
-</div>
-<span class="percentage-text">0.1%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge other">15</span></td>
-<td><a href="https://github.com/alegoupil" class="contributor-link">alegoupil</a></td>
-<td>11</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.10577940186556399%"></div>
-</div>
-<span class="percentage-text">0.1%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge other">16</span></td>
-<td><a href="https://github.com/remydutto" class="contributor-link">remydutto</a></td>
-<td>11</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.10577940186556399%"></div>
-</div>
-<span class="percentage-text">0.1%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge other">17</span></td>
-<td><a href="https://github.com/abavoil" class="contributor-link">abavoil</a></td>
-<td>10</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.09616309260505818%"></div>
-</div>
-<span class="percentage-text">0.1%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge other">18</span></td>
-<td><a href="https://github.com/amontoison" class="contributor-link">amontoison</a></td>
-<td>10</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.09616309260505818%"></div>
-</div>
-<span class="percentage-text">0.1%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge other">19</span></td>
-<td><a href="https://github.com/Ousmane-prog" class="contributor-link">Ousmane-prog</a></td>
-<td>10</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.09616309260505818%"></div>
-</div>
-<span class="percentage-text">0.1%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge other">20</span></td>
-<td><a href="https://github.com/YouriRenoud" class="contributor-link">YouriRenoud</a></td>
-<td>9</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.08654678334455236%"></div>
-</div>
-<span class="percentage-text">0.1%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge other">21</span></td>
-<td><a href="https://github.com/ade4569" class="contributor-link">ade4569</a></td>
-<td>6</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.0576978555630349%"></div>
-</div>
-<span class="percentage-text">0.1%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge other">22</span></td>
-<td><a href="https://github.com/srcansiz" class="contributor-link">srcansiz</a></td>
-<td>5</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.04808154630252909%"></div>
-</div>
-<span class="percentage-text">0.0%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge other">23</span></td>
-<td><a href="https://github.com/michel2323" class="contributor-link">michel2323</a></td>
-<td>4</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.03846523704202327%"></div>
-</div>
-<span class="percentage-text">0.0%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge other">24</span></td>
-<td><a href="https://github.com/tmigot" class="contributor-link">tmigot</a></td>
-<td>3</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.02884892778151745%"></div>
-</div>
-<span class="percentage-text">0.0%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge other">25</span></td>
-<td><a href="https://github.com/oameye" class="contributor-link">oameye</a></td>
-<td>3</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.02884892778151745%"></div>
-</div>
-<span class="percentage-text">0.0%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge other">26</span></td>
-<td><a href="https://github.com/gdalle" class="contributor-link">gdalle</a></td>
-<td>3</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.02884892778151745%"></div>
-</div>
-<span class="percentage-text">0.0%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge other">27</span></td>
-<td><a href="https://github.com/loxim3" class="contributor-link">loxim3</a></td>
-<td>2</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.019232618521011637%"></div>
-</div>
-<span class="percentage-text">0.0%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge other">28</span></td>
-<td><a href="https://github.com/mjacobse" class="contributor-link">mjacobse</a></td>
-<td>1</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.009616309260505818%"></div>
-</div>
-<span class="percentage-text">0.0%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge other">29</span></td>
-<td><a href="https://github.com/vmerc" class="contributor-link">vmerc</a></td>
-<td>1</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.009616309260505818%"></div>
-</div>
-<span class="percentage-text">0.0%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge other">30</span></td>
-<td><a href="https://github.com/Lupylune" class="contributor-link">Lupylune</a></td>
-<td>1</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.009616309260505818%"></div>
-</div>
-<span class="percentage-text">0.0%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge other">31</span></td>
-<td><a href="https://github.com/frapac" class="contributor-link">frapac</a></td>
-<td>1</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.009616309260505818%"></div>
-</div>
-<span class="percentage-text">0.0%</span>
-</div>
-</td>
-</tr>
-<tr>
-<td><span class="rank-badge other">32</span></td>
-<td><a href="https://github.com/BWembe" class="contributor-link">BWembe</a></td>
-<td>1</td>
-<td>
-<div class="contribution-bar">
-<div class="bar-container">
-<div class="bar-fill" style="width: 0.009616309260505818%"></div>
-</div>
-<span class="percentage-text">0.0%</span>
-</div>
-</td>
-</tr>
-</tbody>
-</table>
-</div>
-
-<div class="contributors-section">
-<h2>📈 Additional Statistics</h2>
-<div class="stats-grid">
-<div class="stat-item">
-<strong>Average contributions</strong>
-<span>325.0 commits per contributor</span>
-</div>
-<div class="stat-item">
-<strong>Median contributions</strong>
-<span>10 commits</span>
-</div>
-<div class="stat-item">
-<strong>Top 10 contributions</strong>
-<span>10,232 commits (98.4%)</span>
-</div>
-<div class="stat-item">
-<strong>Other contributors</strong>
-<span>167 commits (1.6%)</span>
-</div>
-</div>
-</div>
-
-<div class="contributors-section">
-<h2>📦 Analyzed Repositories</h2>
+<h2>Repositories</h2>
 <div class="repo-list">
 <h3>AnasXbouali</h3>
 <ul>
@@ -553,9 +104,6 @@ permalink: /contributors/
 </div>
 </div>
 
-<hr>
-<p style="text-align: center; color: #6a737d; font-size: 0.9rem;">
-<em>🤖 This page is automatically generated via the GitHub API and updated weekly.</em>
-</p>
+<p class="generated-note">Automatically generated from GitHub data.</p>
 
 </div>

--- a/assets/css/contributors.css
+++ b/assets/css/contributors.css
@@ -1,416 +1,189 @@
 /* Contributors Page Styles */
 
 .contributors-page {
-    max-width: 1200px;
+    max-width: 900px;
     margin: 0 auto;
-    padding: 0rem 0rem;
+    padding: 0;
+    color: #213547;
+    line-height: 1.7;
 }
 
 .contributors-header {
-    text-align: center;
-    margin-bottom: 3rem;
+    margin-bottom: 2rem;
 }
 
 .contributors-header h1 {
-    font-size: 2.5rem;
-    color: var(--color-text-primary, #24292e);
     margin-bottom: 0.5rem;
+    color: #003d4d;
+    font-size: 2rem;
+    line-height: 1.25;
+}
+
+.contributors-header .subtitle,
+.contributors-header .last-update,
+.generated-note {
+    color: #64748b;
 }
 
 .contributors-header .subtitle {
-    font-size: 1.1rem;
-    color: var(--color-text-secondary, #586069);
-    margin-bottom: 1rem;
-}
-
-.contributors-header .last-update {
-    font-size: 0.9rem;
-    color: var(--color-text-tertiary, #6a737d);
-    font-style: italic;
-}
-
-/* Summary Cards */
-.summary-cards {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 1.5rem;
-    margin: 2rem 0;
-}
-
-.summary-card {
-    color: white;
-    padding: 1.5rem;
-    border-radius: 12px;
-    text-align: center;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.summary-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 8px 12px rgba(0, 0, 0, 0.15);
-}
-
-/* Julia colors */
-.summary-card.card-repos {
-    background: linear-gradient(135deg, #CB3C33 0%, #a02f28 100%);
-}
-
-.summary-card.card-contributors {
-    background: linear-gradient(135deg, #389826 0%, #2d7a1e 100%);
-}
-
-.summary-card.card-commits {
-    background: linear-gradient(135deg, #9558B2 0%, #7a4690 100%);
-}
-
-.summary-card .card-label {
-    font-size: 0.9rem;
-    opacity: 0.9;
     margin-bottom: 0.5rem;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
 }
 
-.summary-card .card-value {
-    font-size: 2.5rem;
-    font-weight: bold;
-    line-height: 1;
+.contributors-header .last-update,
+.generated-note {
+    font-size: 0.9rem;
 }
 
-/* Section Styles */
+.summary {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+    margin: 0 0 2.5rem;
+    padding: 1rem 0;
+    border-top: 1px solid #e2e8f0;
+    border-bottom: 1px solid #e2e8f0;
+}
+
+.summary div {
+    padding: 0 1rem;
+    border-right: 1px solid #e2e8f0;
+    text-align: center;
+}
+
+.summary div:last-child {
+    border-right: 0;
+}
+
+.summary dt {
+    color: #64748b;
+    font-size: 0.9rem;
+}
+
+.summary dd {
+    margin: 0.25rem 0 0;
+    color: #003d4d;
+    font-size: 1.6rem;
+    font-weight: 600;
+}
+
 .contributors-section {
-    margin-bottom: 3rem;
+    margin-bottom: 2.5rem;
 }
 
 .contributors-section h2 {
-    font-size: 1.8rem;
-    color: #24292e;
-    font-weight: 700;
     margin-bottom: 1rem;
-    padding-bottom: 0.5rem;
-    border-bottom: 3px solid #9558B2;
+    color: #005f73;
+    font-size: 1.4rem;
+    font-weight: 600;
+    line-height: 1.4;
 }
 
 .contributors-section h3 {
-    font-size: 1.4rem;
-    color: #24292e;
+    margin: 1.5rem 0 0.5rem;
+    color: #0096a0;
+    font-size: 1.1rem;
     font-weight: 600;
-    margin-top: 2rem;
-    margin-bottom: 1rem;
 }
 
-/* Inline Contributors List */
-.contributors-inline {
-    background: #f6f8fa;
-    padding: 1.5rem;
-    border-radius: 8px;
-    border-left: 4px solid #9558B2;
-    margin-bottom: 2rem;
-    line-height: 1.8;
-}
-
-.contributors-inline .contributor-item {
-    display: inline;
-    margin-right: 0.5rem;
-}
-
-.contributors-inline .contributor-name {
-    font-weight: 600;
-    color: #0366d6;
-}
-
-.contributors-inline .contributor-count {
-    color: #586069;
-}
-
-/* Table Styles */
-.contributors-table {
-    width: 100%;
-    border-collapse: collapse;
-    margin-bottom: 2rem;
-    background: white;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-    border-radius: 8px;
-    overflow: hidden;
-}
-
-.contributors-table thead {
-    background: linear-gradient(135deg, #9558B2 0%, #7a4690 100%);
-    color: white;
-}
-
-.contributors-table th {
-    padding: 1rem;
-    text-align: left;
-    font-weight: 600;
-    text-transform: uppercase;
-    font-size: 0.85rem;
-    letter-spacing: 0.5px;
-}
-
-.contributors-table th:nth-child(1) {
-    width: 80px;
-}
-
-.contributors-table th:nth-child(2) {
-    width: auto;
-}
-
-.contributors-table th:nth-child(3) {
-    width: 150px;
-}
-
-.contributors-table th:nth-child(4) {
-    width: 300px;
-}
-
-.contributors-table tbody tr {
-    border-bottom: 1px solid #e1e4e8;
-    transition: background-color 0.2s ease;
-}
-
-.contributors-table tbody tr:hover {
-    background-color: #f6f8fa;
-}
-
-.contributors-table tbody tr:nth-child(even) {
-    background-color: #fafbfc;
-}
-
-.contributors-table tbody tr:nth-child(even):hover {
-    background-color: #f6f8fa;
-}
-
-.contributors-table td {
-    padding: 1rem;
-}
-
-.contributors-table .rank-badge {
-    display: inline-block;
-    width: 32px;
-    height: 32px;
-    line-height: 32px;
-    text-align: center;
-    border-radius: 50%;
-    font-weight: bold;
-    color: white;
-}
-
-.contributors-table .rank-badge.top-1 {
-    background: linear-gradient(135deg, #ffd700 0%, #ffed4e 100%);
-    color: #333;
-    box-shadow: 0 2px 4px rgba(255, 215, 0, 0.4);
-}
-
-.contributors-table .rank-badge.top-2 {
-    background: linear-gradient(135deg, #c0c0c0 0%, #e8e8e8 100%);
-    color: #333;
-    box-shadow: 0 2px 4px rgba(192, 192, 192, 0.4);
-}
-
-.contributors-table .rank-badge.top-3 {
-    background: linear-gradient(135deg, #cd7f32 0%, #e8a87c 100%);
-    color: white;
-    box-shadow: 0 2px 4px rgba(205, 127, 50, 0.4);
-}
-
-.contributors-table .rank-badge.top-10 {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-}
-
-.contributors-table .rank-badge.other {
-    background: #6a737d;
-}
-
-.contributors-table .contributor-link {
-    color: #0366d6;
-    text-decoration: none;
-    font-weight: 600;
-    transition: color 0.2s ease;
-}
-
-.contributors-table .contributor-link:hover {
-    color: #0256c7;
-    text-decoration: underline;
-}
-
-.contributors-table .contribution-bar {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.contributors-table .bar-container {
-    flex: 1;
-    height: 8px;
-    background: #e1e4e8;
-    border-radius: 4px;
-    overflow: hidden;
-}
-
-.contributors-table .bar-fill {
-    height: 100%;
-    background: linear-gradient(90deg, #667eea 0%, #764ba2 100%);
-    border-radius: 4px;
-    transition: width 0.3s ease;
-}
-
-.contributors-table .percentage-text {
-    font-size: 0.9rem;
-    color: #586069;
-    min-width: 50px;
-    text-align: right;
-}
-
-/* Top Contributors Highlight */
-.top-contributors-list {
-    list-style: none;
-    padding: 0;
+.contributors-list {
     margin: 0;
+    padding-left: 1.5rem;
+    columns: 2;
+    column-gap: 3rem;
 }
 
-.top-contributors-list li {
-    padding: 1rem;
-    margin-bottom: 0.75rem;
-    background: white;
-    border-radius: 8px;
-    border-left: 4px solid #9558B2;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+.contributors-list li {
+    margin-bottom: 0.4rem;
+    break-inside: avoid;
 }
 
-.top-contributors-list li:hover {
-    transform: translateX(4px);
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-}
-
-.top-contributors-list li:nth-child(1) {
-    border-left-color: #ffd700;
-}
-
-.top-contributors-list li:nth-child(2) {
-    border-left-color: #c0c0c0;
-}
-
-.top-contributors-list li:nth-child(3) {
-    border-left-color: #cd7f32;
-}
-
-.top-contributors-list .contributor-name {
-    font-weight: 600;
-    color: #0366d6;
+.contributors-list a,
+.repo-list a {
+    color: #007fa2;
     text-decoration: none;
 }
 
-.top-contributors-list .contributor-name:hover {
+.contributors-list a:hover,
+.repo-list a:hover {
+    color: #005f73;
     text-decoration: underline;
-}
-
-.top-contributors-list .contributor-stats {
-    color: #586069;
-    font-size: 0.95rem;
-}
-
-/* Repository List */
-.repo-list {
-    display: block;
-}
-
-.repo-list h3 {
-    margin-top: 1.5rem;
-    margin-bottom: 0.75rem;
-    color: #24292e;
-    font-weight: 600;
 }
 
 .repo-list ul {
-    margin-bottom: 1.5rem;
-    margin-left: 1.5rem;
+    margin: 0 0 1rem;
+    padding-left: 1.5rem;
 }
 
 .repo-list li {
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.3rem;
 }
 
-.repo-list a {
-    color: #0366d6;
-    text-decoration: none;
-    transition: color 0.2s ease;
+.generated-note {
+    margin-top: 2rem;
+    padding-top: 1rem;
+    border-top: 1px solid #e2e8f0;
 }
 
-.repo-list a:hover {
-    color: #0256c7;
-    text-decoration: underline;
+.dark .contributors-page {
+    color: #cbd5e1;
 }
 
-/* Statistics Grid */
-.stats-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 1rem;
-    margin-bottom: 2rem;
+.dark .contributors-header h1,
+.dark .summary dd {
+    color: #4db8ff;
 }
 
-.stat-item {
-    background: #f6f8fa;
-    padding: 1rem;
-    border-radius: 8px;
-    border-left: 3px solid #9558B2;
+.dark .contributors-section h2 {
+    color: #5ec9d6;
 }
 
-.stat-item strong {
-    display: block;
-    color: #24292e;
-    margin-bottom: 0.25rem;
+.dark .contributors-section h3 {
+    color: #7dd3e0;
 }
 
-.stat-item span {
-    color: #586069;
-    font-size: 0.95rem;
+.dark .contributors-header .subtitle,
+.dark .contributors-header .last-update,
+.dark .summary dt,
+.dark .generated-note {
+    color: #94a3b8;
 }
 
-/* Note/Info Box */
-.info-box {
-    background: #fff8dc;
-    border-left: 4px solid #ffa500;
-    padding: 1rem 1.5rem;
-    border-radius: 4px;
-    margin: 1.5rem 0;
+.dark .summary,
+.dark .summary div,
+.dark .generated-note {
+    border-color: #334155;
 }
 
-.info-box p {
-    margin: 0;
-    color: #856404;
+.dark .contributors-list a,
+.dark .repo-list a {
+    color: #5ec9d6;
 }
 
-/* Responsive Design */
-@media (max-width: 768px) {
-    .contributors-header h1 {
-        font-size: 2rem;
-    }
-    
-    .summary-cards {
+.dark .contributors-list a:hover,
+.dark .repo-list a:hover {
+    color: #7dd3e0;
+}
+
+@media (max-width: 600px) {
+    .summary {
         grid-template-columns: 1fr;
     }
-    
-    .contributors-table {
-        font-size: 0.9rem;
+
+    .summary div {
+        padding: 0.5rem 0;
+        border-right: 0;
+        border-bottom: 1px solid #e2e8f0;
     }
-    
-    .contributors-table th,
-    .contributors-table td {
-        padding: 0.75rem 0.5rem;
+
+    .summary div:last-child {
+        border-bottom: 0;
     }
-    
-    .repo-list {
+
+    .contributors-list {
         columns: 1;
     }
-    
-    .stats-grid {
-        grid-template-columns: 1fr;
+
+    .dark .summary div {
+        border-bottom-color: #334155;
     }
 }
-
-/* Dark Mode Support - Disabled to avoid visibility issues */
-/* Users can enable it manually if needed */

--- a/scripts/contributors/github_contributors.py
+++ b/scripts/contributors/github_contributors.py
@@ -480,145 +480,34 @@ def generate_web_page(contributors: Dict[str, int], packages: List[Tuple[str, st
         
         # Header
         f.write('<div class="contributors-header">\n')
-        f.write('<h1>🌟 Contributors</h1>\n')
-        f.write('<p class="subtitle">Thank you to all the amazing people who have contributed to the control-toolbox ecosystem!</p>\n')
+        f.write('<h1>Contributors</h1>\n')
+        f.write('<p class="subtitle">Contributors to the control-toolbox ecosystem</p>\n')
         france_time = datetime.now(timezone.utc).astimezone(ZoneInfo("Europe/Paris"))
         f.write(f'<p class="last-update">Last updated: {france_time.strftime("%B %d, %Y at %H:%M")} (France)</p>\n')
         f.write('</div>\n\n')
         
-        # Summary cards
-        f.write('<div class="summary-cards">\n')
-        f.write('<div class="summary-card card-repos">\n')
-        f.write('<div class="card-label">Repositories</div>\n')
-        f.write(f'<div class="card-value">{len(packages)}</div>\n')
-        f.write('</div>\n')
-        f.write('<div class="summary-card card-contributors">\n')
-        f.write('<div class="card-label">Contributors</div>\n')
-        f.write(f'<div class="card-value">{len(sorted_contributors)}</div>\n')
-        f.write('</div>\n')
-        f.write('<div class="summary-card card-commits">\n')
-        f.write('<div class="card-label">Total Commits</div>\n')
-        f.write(f'<div class="card-value">{total_contributions:,}</div>\n')
-        f.write('</div>\n')
-        f.write('</div>\n\n')
-        
-        # Info note
-        f.write('<div class="info-box">\n')
-        f.write('<p><strong>Note:</strong> Contributions represent commits made to the repositories. ')
-        if exclude_bots:
-            f.write('Bots are excluded from the statistics. ')
-        if exclude_names:
-            f.write(f'Excluded contributors: {", ".join(exclude_names)}.')
-        f.write('</p>\n')
-        f.write('</div>\n\n')
-        
-        # Inline list of contributors
+        # Summary
+        f.write('<dl class="summary">\n')
+        f.write('<div><dt>Repositories</dt>\n')
+        f.write(f'<dd>{len(packages)}</dd></div>\n')
+        f.write('<div><dt>Contributors</dt>\n')
+        f.write(f'<dd>{len(sorted_contributors)}</dd></div>\n')
+        f.write('<div><dt>Total commits</dt>\n')
+        f.write(f'<dd>{total_contributions:,}</dd></div>\n')
+        f.write('</dl>\n\n')
+
+        # Contributor list
         f.write('<div class="contributors-section">\n')
-        f.write('<h2>👥 All Contributors</h2>\n')
-        f.write('<div class="contributors-inline">\n')
-        inline_list = ", ".join([f'<span class="contributor-item"><a href="https://github.com/{name}" class="contributor-name">{name}</a> <span class="contributor-count">({contrib})</span></span>' 
-                                 for name, contrib in sorted_contributors])
-        f.write(f'{inline_list}\n')
-        f.write('</div>\n')
-        f.write('</div>\n\n')
-        
-        # Top 10 contributors
-        f.write('<div class="contributors-section">\n')
-        f.write('<h2>🏆 Top 10 Contributors</h2>\n')
-        f.write('<ol class="top-contributors-list">\n')
-        for i, (name, contrib) in enumerate(sorted_contributors[:10], 1):
-            percentage = (contrib / total_contributions) * 100
-            f.write(f'<li><a href="https://github.com/{name}" class="contributor-name">{name}</a> — ')
-            f.write(f'<span class="contributor-stats">{contrib:,} contributions ({percentage:.1f}%)</span></li>\n')
+        f.write('<h2>Contributors</h2>\n')
+        f.write('<ol class="contributors-list">\n')
+        for name, _ in sorted_contributors:
+            f.write(f'<li><a href="https://github.com/{name}">{name}</a></li>\n')
         f.write('</ol>\n')
         f.write('</div>\n\n')
-        
-        # Detailed ranking
+
+        # Repository list
         f.write('<div class="contributors-section">\n')
-        f.write('<h2>📊 Detailed Ranking</h2>\n')
-        f.write('<table class="contributors-table">\n')
-        f.write('<thead>\n')
-        f.write('<tr>\n')
-        f.write('<th>Rank</th>\n')
-        f.write('<th>Contributor</th>\n')
-        f.write('<th>Contributions</th>\n')
-        f.write('<th>Percentage</th>\n')
-        f.write('</tr>\n')
-        f.write('</thead>\n')
-        f.write('<tbody>\n')
-        
-        for i, (name, contrib) in enumerate(sorted_contributors, 1):
-            percentage = (contrib / total_contributions) * 100
-            
-            # Determine badge class
-            if i == 1:
-                badge_class = "top-1"
-            elif i == 2:
-                badge_class = "top-2"
-            elif i == 3:
-                badge_class = "top-3"
-            elif i <= 10:
-                badge_class = "top-10"
-            else:
-                badge_class = "other"
-            
-            f.write('<tr>\n')
-            f.write(f'<td><span class="rank-badge {badge_class}">{i}</span></td>\n')
-            f.write(f'<td><a href="https://github.com/{name}" class="contributor-link">{name}</a></td>\n')
-            f.write(f'<td>{contrib:,}</td>\n')
-            f.write('<td>\n')
-            f.write('<div class="contribution-bar">\n')
-            f.write('<div class="bar-container">\n')
-            f.write(f'<div class="bar-fill" style="width: {percentage}%"></div>\n')
-            f.write('</div>\n')
-            f.write(f'<span class="percentage-text">{percentage:.1f}%</span>\n')
-            f.write('</div>\n')
-            f.write('</td>\n')
-            f.write('</tr>\n')
-        
-        f.write('</tbody>\n')
-        f.write('</table>\n')
-        f.write('</div>\n\n')
-        
-        # Additional statistics
-        f.write('<div class="contributors-section">\n')
-        f.write('<h2>📈 Additional Statistics</h2>\n')
-        f.write('<div class="stats-grid">\n')
-        
-        avg_contrib = total_contributions / len(sorted_contributors)
-        median_contrib = sorted_contributors[len(sorted_contributors)//2][1]
-        top_10_contrib = sum(contrib for _, contrib in sorted_contributors[:10])
-        top_10_percentage = (top_10_contrib / total_contributions) * 100
-        
-        f.write('<div class="stat-item">\n')
-        f.write('<strong>Average contributions</strong>\n')
-        f.write(f'<span>{avg_contrib:.1f} commits per contributor</span>\n')
-        f.write('</div>\n')
-        
-        f.write('<div class="stat-item">\n')
-        f.write('<strong>Median contributions</strong>\n')
-        f.write(f'<span>{median_contrib} commits</span>\n')
-        f.write('</div>\n')
-        
-        f.write('<div class="stat-item">\n')
-        f.write('<strong>Top 10 contributions</strong>\n')
-        f.write(f'<span>{top_10_contrib:,} commits ({top_10_percentage:.1f}%)</span>\n')
-        f.write('</div>\n')
-        
-        if len(sorted_contributors) > 10:
-            others_contrib = total_contributions - top_10_contrib
-            others_percentage = (others_contrib / total_contributions) * 100
-            f.write('<div class="stat-item">\n')
-            f.write('<strong>Other contributors</strong>\n')
-            f.write(f'<span>{others_contrib:,} commits ({others_percentage:.1f}%)</span>\n')
-            f.write('</div>\n')
-        
-        f.write('</div>\n')
-        f.write('</div>\n\n')
-        
-        # Analyzed repositories
-        f.write('<div class="contributors-section">\n')
-        f.write('<h2>📦 Analyzed Repositories</h2>\n')
+        f.write('<h2>Repositories</h2>\n')
         f.write('<div class="repo-list">\n')
         
         # Group by owner
@@ -637,10 +526,7 @@ def generate_web_page(contributors: Dict[str, int], packages: List[Tuple[str, st
         f.write('</div>\n\n')
         
         # Footer
-        f.write('<hr>\n')
-        f.write('<p style="text-align: center; color: #6a737d; font-size: 0.9rem;">\n')
-        f.write('<em>🤖 This page is automatically generated via the GitHub API and updated weekly.</em>\n')
-        f.write('</p>\n\n')
+        f.write('<p class="generated-note">Automatically generated from GitHub data.</p>\n\n')
         
         # Close container
         f.write('</div>\n')
@@ -761,6 +647,7 @@ Usage examples:
             ("control-toolbox", "CTSolvers.jl"),
             ("control-toolbox", "CTModels.jl"),
             ("control-toolbox", "CTBase.jl"),
+            ("control-toolbox", "CTLie.jl"),
             ("control-toolbox", "CTBenchmarks.jl"),
             ("control-toolbox", "CTDiffFlow.jl"),
             ("control-toolbox", "OptimalControlProblems.jl"),


### PR DESCRIPTION
## Summary
- Simplify the contributors page by removing contribution rankings and detailed statistics.
- Keep the repository count, contributor count, total commits, repository list, and ordered contributor list without contribution counts.
- Align the page CSS with the DocumenterVitepress visual style and add dark-mode support.
- Update the generator so the automated workflow preserves the new layout.

## Test plan
- [x] Generate the page with the authenticated GitHub CLI token via `gh auth token`.
- [x] Verify 25 repositories, 32 contributors, and 10,400 total commits.
- [x] Verify the contributor list contains names only and no ranking/statistics sections.
- [x] Run `LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 bundle exec jekyll build`.
- [x] Serve and check `/contributors/` locally at `http://127.0.0.1:4000/contributors/`.

Generated with [Devin](https://devin.ai)