### PR TITLE
Refine citations and applications pages

### DIFF
--- a/about/citations.md
+++ b/about/citations.md
@@ -9,24 +9,13 @@ permalink: /citations/
 <div class="citations-page">
 
 <div class="citations-header">
-<h1>📚 Citations</h1>
+<h1>Citations</h1>
 <p class="subtitle">Academic papers citing OptimalControl.jl and related control-toolbox projects</p>
 <p class="last-update">Last updated: July 27, 2026 at 00:33 UTC</p>
 </div>
 
-<div class="summary-cards">
-<div class="summary-card card-citations">
-<div class="card-label">Total Citations</div>
-<div class="card-value">10</div>
-</div>
-</div>
-
-<div class="info-box">
-<p><strong>Note:</strong> This page lists academic papers that cite OptimalControl.jl and related control-toolbox projects. Data is automatically retrieved from Google Scholar.</p>
-</div>
-
 <div class="citations-section">
-<h2>📖 Citations</h2>
+<h2>Citations (10)</h2>
 <div class="citations-list">
 <div class="citation-item">
 <h3 class="citation-title"><a href="https://joss.theoj.org/papers/10.21105/joss.10229.pdf" target="_blank">1. Uno: a composable framework for nonlinearly constrained optimization</a></h3>
@@ -81,9 +70,6 @@ permalink: /citations/
 </div>
 </div>
 
-<hr>
-<p style="text-align: center; color: #6a737d; font-size: 0.9rem;">
-<em>🤖 This page is automatically generated from Google Scholar and updated weekly.</em>
-</p>
+<p class="generated-note">Automatically generated from Google Scholar.</p>
 
 </div>

--- a/applications/index.md
+++ b/applications/index.md
@@ -102,7 +102,7 @@ custom_js:
 <div class="apps-main">
 
 <div class="contributors-header">
-<h1>🚀 Applications</h1>
+<h1>Applications</h1>
 <p class="subtitle">A collection of optimal control applications built with the control-toolbox ecosystem.</p>
 </div>
 

--- a/assets/css/applications.css
+++ b/assets/css/applications.css
@@ -40,7 +40,7 @@
 }
 
 /* Mobile portrait ONLY - collapsible filters */
-@media (max-width: 480px) and (orientation: portrait) {
+@media (max-width: 480px) { /* and (orientation: portrait) */
     .apps-layout {
         grid-template-columns: 1fr;
         margin-left: 0;
@@ -199,11 +199,15 @@
     }
 
     .apps-main .contributors-header {
-        display: none;
+        margin-bottom: 1.5rem;
+    }
+
+    .apps-main .contributors-header h1 {
+        font-size: 1.75rem;
     }
 
     .apps-cta {
-        display: none;
+        margin-bottom: 1rem;
     }
 
     .view-toggle-bar {
@@ -260,7 +264,7 @@
 }
 
 /* Landscape mode - drawer sidebar (≤768px in landscape OR small height) */
-@media (max-width: 900px) and (orientation: landscape) {
+@media (max-width: 900px) and (min-width: 480px) { /* and (orientation: landscape) */
     /* Change layout to 1 column since sidebar is fixed */
     .apps-layout {
         grid-template-columns: 1fr;
@@ -371,11 +375,15 @@
     }
 
     .apps-main .contributors-header {
-        display: none;
+        margin-bottom: 1rem;
+    }
+
+    .apps-main .contributors-header h1 {
+        font-size: 1.5rem;
     }
 
     .apps-cta {
-        display: none;
+        margin-bottom: 0.75rem;
     }
 
     .app-grid {
@@ -437,18 +445,17 @@
 }
 
 .filter-counter-box {
-    background: var(--color-canvas-default, #ffffff);
-    border: 1px solid var(--color-border-default, #e1e4e8);
-    border-radius: 8px;
-    padding: 0.75rem 1rem;
-    text-align: center;
     margin-bottom: 1rem;
+    padding: 0;
+    background: transparent;
+    border: 0;
+    text-align: left;
 }
 
 .filter-counter {
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--color-text-primary, #24292e);
+    color: #64748b;
+    font-size: 0.85rem;
+    font-weight: 500;
 }
 
 /* Search box */
@@ -599,10 +606,11 @@
     flex-direction: column;
     background: var(--color-canvas-default, #ffffff);
     border: 1px solid var(--color-border-default, #e1e4e8);
-    border-radius: 12px;
+    border-left: 3px solid #007fa2;
+    border-radius: 4px;
     overflow: hidden;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    transition: transform 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
+    transform-origin: center;
     text-decoration: none;
     color: inherit;
     width: 100%;
@@ -610,8 +618,10 @@
 }
 
 .app-card:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
+    transform: scale(1.01);
+    border-color: #005f73;
+    border-left-color: #005f73;
+    background: #f8fafc;
 }
 
 .app-header {
@@ -627,10 +637,13 @@
     font-family: 'JuliaMono', monospace, 'Courier New', monospace;
     font-size: 1.5rem;
     font-weight: 700;
-    background: var(--app-color, #CB3C33);
-    color: white;
-    padding: 0.5rem 0.75rem;
-    border-radius: 8px;
+    line-height: 1.2;
+    background: #f8fafc;
+    border: 1px solid #b6dfe5;
+    color: #005f73;
+    transition: background-color 0.15s ease, border-color 0.15s ease;
+    padding: 0.3rem 0.75rem;
+    border-radius: 4px;
     width: 125px;
     text-align: center;
     flex-shrink: 0;
@@ -639,25 +652,53 @@
 .app-title {
     font-size: 1.25rem;
     font-weight: 600;
-    color: var(--color-text-primary, #24292e);
+    line-height: 1.3;
+    text-align: left;
+    color: #005f73;
     text-decoration: none;
     flex: 1;
 }
 
+.app-card:hover .app-avatar-text {
+    background: #e2e8f0;
+    border-color: #cbd5e1;
+}
+
 .app-card:hover .app-title {
-    text-decoration: underline;
+    text-decoration: none;
 }
 
 .app-body {
     padding: 1rem 1.75rem 1rem;
-    background: white;
+    background: var(--color-canvas-default, #ffffff);
 }
 
 .app-summary {
     font-size: 0.95rem;
+    text-align: left;
     color: var(--color-text-secondary, #585c60);
     line-height: 1.6;
     margin: 0 !important;
+}
+
+.dark .app-card:hover {
+    background: #172033;
+    border-color: #5ec9d6;
+}
+
+.dark .app-avatar-text {
+    background: #172033;
+    border-color: #347b86;
+    color: #7dd3e0;
+}
+
+.dark .app-card:hover .app-avatar-text {
+    background: #334155;
+    border-color: #5ec9d6;
+}
+
+.dark .app-title {
+    color: #5ec9d6;
 }
 
 /* Compact view */
@@ -684,12 +725,7 @@
 }
 
 .app-grid.compact .app-card {
-    border-radius: 8px;
-    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
-}
-
-.app-grid.compact .app-card:hover {
-    transform: translateY(-2px);
+    border-radius: 4px;
 }
 
 /* Tags on cards */

--- a/assets/css/citations.css
+++ b/assets/css/citations.css
@@ -1,94 +1,51 @@
 /* Citations Page Styles */
 
 .citations-page {
-    max-width: 1200px;
+    max-width: 900px;
     margin: 0 auto;
-    padding: 0rem 0rem;
+    padding: 0;
+    color: #213547;
+    line-height: 1.7;
 }
 
 .citations-header {
-    text-align: center;
-    margin-bottom: 3rem;
+    margin-bottom: 2rem;
 }
 
 .citations-header h1 {
-    font-size: 2.5rem;
-    color: var(--color-text-primary, #24292e);
     margin-bottom: 0.5rem;
+    color: #003d4d;
+    font-size: 2rem;
+    line-height: 1.25;
+}
+
+.citations-header .subtitle,
+.citations-header .last-update,
+.generated-note {
+    color: #64748b;
 }
 
 .citations-header .subtitle {
-    font-size: 1.1rem;
-    color: var(--color-text-secondary, #586069);
-    margin-bottom: 1rem;
+    margin-bottom: 0.5rem;
 }
 
-.citations-header .last-update {
+.citations-header .last-update,
+.generated-note {
     font-size: 0.9rem;
-    color: var(--color-text-tertiary, #6a737d);
-    font-style: italic;
 }
 
-/* Summary Cards */
-.summary-cards {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 1.5rem;
-    margin: 2rem 0;
-}
-
-.summary-card {
-    color: white;
-    padding: 1.5rem;
-    border-radius: 12px;
-    text-align: center;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: center;
-    gap: 1rem;
-}
-
-.summary-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 8px 12px rgba(0, 0, 0, 0.15);
-}
-
-/* Julia colors adapted for citations */
-.summary-card.card-citations {
-    background: linear-gradient(135deg, #389826 0%, #2d7a1e 100%);
-}
-
-.summary-card .card-label {
-    font-size: 1.2rem;
-    opacity: 0.9;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-}
-
-.summary-card .card-value {
-    font-size: 2.5rem;
-    font-weight: bold;
-    line-height: 1;
-}
-
-/* Section Styles */
 .citations-section {
-    margin-bottom: 3rem;
+    margin-bottom: 2.5rem;
 }
 
 .citations-section h2 {
-    font-size: 1.8rem;
-    color: #24292e;
-    font-weight: 700;
     margin-bottom: 1rem;
-    padding-bottom: 0.5rem;
-    border-bottom: 3px solid #389826;
+    color: #005f73;
+    font-size: 1.4rem;
+    font-weight: 600;
+    line-height: 1.4;
 }
 
-/* Citations List */
 .citations-list {
     display: flex;
     flex-direction: column;
@@ -96,105 +53,144 @@
 }
 
 .citation-item {
-    background: white;
-    padding: 1rem;
-    border-radius: 8px;
-    border-left: 4px solid #389826;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    position: relative;
+    padding: 1rem 1.25rem;
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-left: 3px solid #007fa2;
+    border-radius: 4px;
+    text-align: left;
+    cursor: pointer;
+    transition: transform 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
 }
 
 .citation-item:hover {
-    transform: translateX(4px);
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    transform: scale(1.01);
+    border-color: #005f73;
+    border-left-color: #005f73;
+    background: #f8fafc;
 }
 
 .citation-title {
-    font-size: 1.2rem;
+    margin: 0 0 0.5rem !important;
+    color: #005f73;
+    font-size: 1.1rem;
     font-weight: 600;
-    color: #24292e;
-    margin-top: 0 !important;
-    margin-bottom: 0.75rem;
     line-height: 1.4;
 }
 
-.citation-title a {
-    color: #0366d6;
+.citation-title a,
+.citation-link a,
+.citation-alt a {
+    color: #007fa2;
     text-decoration: none;
-    transition: color 0.2s ease;
 }
 
-.citation-title a:hover {
-    color: #0256c7;
-    text-decoration: underline;
+.citation-title a::after {
+    position: absolute;
+    inset: 0;
+    content: "";
+}
+
+.citation-alt,
+.citation-alt a {
+    position: relative;
+    z-index: 1;
+}
+
+.citation-title a:hover,
+.citation-link a:hover,
+.citation-alt a:hover {
+    color: #005f73;
+    text-decoration: none;
 }
 
 .citation-authors {
+    margin: 0 0 0.5rem;
+    color: #64748b;
     font-size: 0.95rem;
-    color: #586069;
-    margin-bottom: 0.5rem;
-    font-style: italic;
 }
 
 .citation-snippet {
+    margin: 0;
+    color: #475569;
     font-size: 0.9rem;
-    color: #6a737d;
-    margin-bottom: 0rem !important;
     line-height: 1.6;
 }
 
-.citation-link {
+.citation-alt {
+    margin: 0.5rem 0 0;
+    color: #64748b;
     font-size: 0.85rem;
-    margin-bottom: 0;
 }
 
-.citation-link a {
-    color: #0366d6;
-    text-decoration: none;
-    font-weight: 500;
-}
-
-.citation-link a:hover {
-    color: #0256c7;
-    text-decoration: underline;
-}
-
-.citation-divider {
-    border: none;
-    height: 1px;
-    background: #e1e4e8;
-    margin: 0;
-}
-
-/* Note/Info Box */
 .info-box {
-    background: #fff8dc;
-    border-left: 4px solid #ffa500;
-    padding: 1rem 1.5rem;
-    border-radius: 4px;
     margin: 1.5rem 0;
+    padding: 0.75rem 1rem;
+    border-left: 3px solid #007fa2;
+    color: #475569;
+    background: #f8fafc;
 }
 
 .info-box p {
     margin: 0;
-    color: #856404;
 }
 
-/* Responsive Design */
-@media (max-width: 768px) {
-    .citations-header h1 {
-        font-size: 2rem;
-    }
-    
-    .summary-cards {
-        grid-template-columns: 1fr;
-    }
-    
-    .citation-item {
-        padding: 1rem;
-    }
-    
-    .citation-title {
-        font-size: 1.1rem;
-    }
+.generated-note {
+    margin-top: 2rem;
+    padding-top: 1rem;
+    border-top: 1px solid #e2e8f0;
+}
+
+.dark .citations-page {
+    color: #cbd5e1;
+}
+
+.dark .citations-header h1 {
+    color: #4db8ff;
+}
+
+.dark .citations-section h2,
+.dark .citation-title {
+    color: #5ec9d6;
+}
+
+.dark .citations-header .subtitle,
+.dark .citations-header .last-update,
+.dark .citation-authors,
+.dark .citation-alt,
+.dark .generated-note {
+    color: #94a3b8;
+}
+
+.dark .generated-note,
+.dark .citation-item {
+    border-color: #334155;
+}
+
+.dark .citation-item {
+    background: #0f172a;
+    border-left-color: #5ec9d6;
+}
+
+.dark .citation-snippet,
+.dark .info-box {
+    color: #cbd5e1;
+}
+
+.dark .citation-title a,
+.dark .citation-link a,
+.dark .citation-alt a {
+    color: #5ec9d6;
+}
+
+.dark .citation-title a:hover,
+.dark .citation-link a:hover,
+.dark .citation-alt a:hover {
+    color: #7dd3e0;
+}
+
+.dark .info-box {
+    background: #172033;
+    border-left-color: #5ec9d6;
 }

--- a/scripts/citations/generate_citations_page.py
+++ b/scripts/citations/generate_citations_page.py
@@ -125,27 +125,14 @@ def generate_web_page(citations: List[Dict], scholar_url: str,
         
         # Header
         f.write('<div class="citations-header">\n')
-        f.write('<h1>📚 Citations</h1>\n')
+        f.write('<h1>Citations</h1>\n')
         f.write('<p class="subtitle">Academic papers citing OptimalControl.jl and related control-toolbox projects</p>\n')
         f.write(f'<p class="last-update">Last updated: {datetime.now().strftime("%B %d, %Y at %H:%M UTC")}</p>\n')
         f.write('</div>\n\n')
         
-        # Summary cards
-        f.write('<div class="summary-cards">\n')
-        f.write('<div class="summary-card card-citations">\n')
-        f.write('<div class="card-label">Total Citations</div>\n')
-        f.write(f'<div class="card-value">{len(citations)}</div>\n')
-        f.write('</div>\n')
-        f.write('</div>\n\n')
-        
-        # Info note
-        f.write('<div class="info-box">\n')
-        f.write('<p><strong>Note:</strong> This page lists academic papers that cite OptimalControl.jl and related control-toolbox projects. Data is automatically retrieved from Google Scholar.</p>\n')
-        f.write('</div>\n\n')
-        
         # Citations list
         f.write('<div class="citations-section">\n')
-        f.write('<h2>📖 Citations</h2>\n')
+        f.write(f'<h2>Citations ({len(citations)})</h2>\n')
         f.write('<div class="citations-list">\n')
         
         for i, citation in enumerate(citations, 1):
@@ -185,10 +172,7 @@ def generate_web_page(citations: List[Dict], scholar_url: str,
         f.write('</div>\n\n')
         
         # Footer
-        f.write('<hr>\n')
-        f.write('<p style="text-align: center; color: #6a737d; font-size: 0.9rem;">\n')
-        f.write('<em>🤖 This page is automatically generated from Google Scholar and updated weekly.</em>\n')
-        f.write('</p>\n\n')
+        f.write('<p class="generated-note">Automatically generated from Google Scholar.</p>\n\n')
         
         # Close container
         f.write('</div>\n')


### PR DESCRIPTION
## Summary
- Simplify the citations page and align it with the DocumenterVitepress visual style.
- Move the citation count into the section heading as `Citations (10)`.
- Make citation cards left-aligned, fully clickable, and subtly enlarge them on hover without underlining the title.
- Restyle application cards with a neutral background, a single teal accent border, compact badges, and a subtle gray badge hover state.
- Keep application titles and descriptions visible and left-aligned on small screens.
- Preserve the existing citation data, application filters, tags, and detailed/compact views.

## Test plan
- [x] Run `LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 bundle exec jekyll build`.
- [x] Run `git diff --check`.
- [x] Verify 10 citation entries remain present.
- [x] Verify 9 application cards and filter controls remain present.
- [x] Verify the applications header and CTA remain visible at small widths.
- [x] Verify the citation card hover and full-card link styles are present.

Generated with [Devin](https://devin.ai)